### PR TITLE
Its return stdClass

### DIFF
--- a/src/KiteConnect.php
+++ b/src/KiteConnect.php
@@ -786,7 +786,7 @@ class KiteConnect
      * @throws PermissionException
      * @throws TokenException
      */
-    public function getLTP(array $instruments): mixed
+    public function getLTP(array $instruments): stdClass
     {
         return $this->get("market.quote.ltp", ["i" => $instruments]);
     }


### PR DESCRIPTION
I have face issue to fetch only LTP. When I tried to used getLTP Method it show below error

Fatal error: Uncaught TypeError: Return value of KiteConnect\KiteConnect::getLTP() must be an instance of KiteConnect\mixed, instance of stdClass returned in *\vendor\zerodha\phpkiteconnect\src\KiteConnect.php:791
Stack trace:
#0 *\test.php(28): KiteConnect\KiteConnect->getLTP(Array)
#1 {main}
thrown in *\vendor\zerodha\phpkiteconnect\src\KiteConnect.php on line 791


I solved this issue to change some code on KiteConnect.php
1. Old Code KiteConnect.php on line No 789

public function getLTP(array $instruments): mixed
{
return $this->get("market.quote.ltp", ["i" => $instruments]);
}

2. New Code To change

public function getLTP(array $instruments): stdClass
{
return $this->get("market.quote.ltp", ["i" => $instruments]);
}