### PR TITLE
chores: update default InputException status code to 400

### DIFF
--- a/src/Exception/InputException.php
+++ b/src/Exception/InputException.php
@@ -15,7 +15,7 @@ class InputException extends KiteException
      * @param Exception|null $previous
      * @return void
      */
-    public function __construct($message, int $code = 500, Exception $previous = null)
+    public function __construct($message, int $code = 400, Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
Update default InputException status code to 400, as used in the [py-client](https://github.com/zerodha/pykiteconnect/blob/e6fe14dd403d0af4ee56ce8aa862bbf7352e3795/kiteconnect/exceptions.py#L62) and [go-client](https://github.com/zerodha/gokiteconnect/blob/bb43544a589eff79527a20847c7df1fd9dff298a/errors.go#L56).